### PR TITLE
-Exposing properties of FunctionInfo

### DIFF
--- a/Runtime/Models/FunctionInfo.swift
+++ b/Runtime/Models/FunctionInfo.swift
@@ -24,10 +24,10 @@ import Foundation
 
 
 public struct FunctionInfo {
-    var numberOfArguments: Int
-    var argumentTypes: [Any.Type]
-    var returnType: Any.Type
-    var `throws`: Bool
+    public var numberOfArguments: Int
+    public var argumentTypes: [Any.Type]
+    public var returnType: Any.Type
+    public var `throws`: Bool
 }
 
 


### PR DESCRIPTION
Guessing these were meant to be public...unless in the spirit of the Runtime library I was only meant to reflect those values using property.get() 😄.