### PR TITLE
use UnsafeBufferPointer for generic arguments

### DIFF
--- a/Sources/Runtime/Metadata/ClassMetadata.swift
+++ b/Sources/Runtime/Metadata/ClassMetadata.swift
@@ -73,7 +73,7 @@ struct ClassMetadata: NominalMetadataType {
         var info = TypeInfo(metadata: self)
         info.mangledName = mangledName()
         info.properties = properties()
-        info.genericTypes = genericArguments()
+        info.genericTypes = Array(genericArguments())
         
         var superClass = superClassMetadata()
         while var sc = superClass {

--- a/Sources/Runtime/Metadata/EnumMetadata.swift
+++ b/Sources/Runtime/Metadata/EnumMetadata.swift
@@ -45,7 +45,7 @@ struct EnumMetadata: NominalMetadataType {
         var info = TypeInfo(metadata: self)
         info.mangledName = mangledName()
         info.cases = cases()
-        info.genericTypes = genericArguments()
+        info.genericTypes = Array(genericArguments())
         return info
     }
 }

--- a/Sources/Runtime/Metadata/NominalMetadataType.swift
+++ b/Sources/Runtime/Metadata/NominalMetadataType.swift
@@ -72,7 +72,7 @@ extension NominalMetadataType {
                 name: record.pointee.fieldName(),
                 type: record.pointee.type(
                     genericContext: pointer.pointee.typeDescriptor,
-                    genericArguments: genericVector.pointee.element(at: 0)
+                    genericArguments: genericVector
                 ),
                 isVar: record.pointee.isVar,
                 offset: offsets[i],
@@ -81,26 +81,21 @@ extension NominalMetadataType {
         }
     }
     
-    func genericArguments() -> [Any.Type] {
-        guard isGeneric else { return [] }
+    func genericArguments() -> UnsafeMutableBufferPointer<Any.Type> {
+        guard isGeneric else { return .init(start: nil, count: 0) }
         
-        let genericHeader = pointer.pointee
+        let count = pointer.pointee
             .typeDescriptor
             .pointee
             .genericContextHeader
-        
-        guard genericHeader.base.numberOfParams > 0 else { return [] }
-        
-        let vector = genericArgumentVector()
-        
-        return (0..<Int(genericHeader.base.numberOfParams)).map { i in
-            return vector.pointee.element(at: i).pointee
-        }
+            .base
+            .numberOfParams
+        return genericArgumentVector().buffer(n: Int(count))
     }
     
-    func genericArgumentVector() -> UnsafeMutablePointer<Vector<Any.Type>> {
+    func genericArgumentVector() -> UnsafeMutablePointer<Any.Type> {
         return pointer
             .advanced(by: genericArgumentOffset, wordSize: MemoryLayout<UnsafeRawPointer>.size)
-            .assumingMemoryBound(to: Vector<Any.Type>.self)
+            .assumingMemoryBound(to: Any.Type.self)
     }
 }

--- a/Sources/Runtime/Metadata/StructMetadata.swift
+++ b/Sources/Runtime/Metadata/StructMetadata.swift
@@ -30,7 +30,7 @@ struct StructMetadata: NominalMetadataType {
         var info = TypeInfo(metadata: self)
         info.properties = properties()
         info.mangledName = mangledName()
-        info.genericTypes = genericArguments()
+        info.genericTypes = Array(genericArguments())
         return info
     }
 }


### PR DESCRIPTION
`TypeInfo.genericTypes` could be `UnsafeBufferPointer` too. Though it requires major version change.