### PR TITLE
Remove unused function with a typo in its name

### DIFF
--- a/Sources/Runtime/Layouts/FieldDescriptor.swift
+++ b/Sources/Runtime/Layouts/FieldDescriptor.swift
@@ -52,11 +52,7 @@ struct FieldRecord {
     mutating func fieldName() -> String {
         return String(cString: _fieldName.advanced())
     }
-    
-    mutating func mangedTypeName() -> String {
-        return String(cString: _mangledTypeName.advanced())
-    }
-    
+
     mutating func type(genericContext: UnsafeRawPointer?,
                        genericArguments: UnsafeRawPointer?) -> Any.Type {
         let typeName = _mangledTypeName.advanced()


### PR DESCRIPTION
Should have been `mangledTypeName`, but looks like it's not used at all anywhere.