### PR TITLE
Fix memory leak with setters

### DIFF
--- a/Sources/Runtime/Factory/Factory.swift
+++ b/Sources/Runtime/Factory/Factory.swift
@@ -83,7 +83,7 @@ func setProperties(typeInfo: TypeInfo,
         
         let valuePointer = pointer.advanced(by: property.offset)
         let sets = setters(type: property.type)
-        sets.set(value: value, pointer: valuePointer)
+        sets.set(value: value, pointer: valuePointer, initialize: true)
     }
 }
 

--- a/Sources/Runtime/Utilities/GettersSetters.swift
+++ b/Sources/Runtime/Utilities/GettersSetters.swift
@@ -34,9 +34,14 @@ func getters(type: Any.Type) -> Getters.Type {
 
 protocol Setters {}
 extension Setters {
-    static func set(value: Any, pointer: UnsafeMutableRawPointer) {
+    static func set(value: Any, pointer: UnsafeMutableRawPointer, initialize: Bool = false) {
         if let value = value as? Self {
-            pointer.assumingMemoryBound(to: self).pointee = value
+            let boundPointer = pointer.assumingMemoryBound(to: self);
+            if initialize {
+                boundPointer.initialize(to: value)
+            } else {
+                boundPointer.pointee = value
+            }
         }
     }
 }

--- a/Sources/Runtime/Utilities/GettersSetters.swift
+++ b/Sources/Runtime/Utilities/GettersSetters.swift
@@ -36,7 +36,7 @@ protocol Setters {}
 extension Setters {
     static func set(value: Any, pointer: UnsafeMutableRawPointer) {
         if let value = value as? Self {
-            pointer.assumingMemoryBound(to: self).initialize(to: value)
+            pointer.assumingMemoryBound(to: self).pointee = value
         }
     }
 }


### PR DESCRIPTION
This PR aims to fix issue #64, which reports a memory leak when setting a field which stores a reference type.

Unfortunately, I'm not very familiar with raw memory manipulation, so I'm not 100% sure whether this is the correct thing to do in all cases, but it appears to address the issue when I apply this fix in our project.

I wasn't able to run the tests locally, but I'm happy to look into any tests this PR breaks.