### PR TITLE
Fix swift 5.4 linux compatibility

### DIFF
--- a/Sources/Runtime/Layouts/ClassMetadataLayout.swift
+++ b/Sources/Runtime/Layouts/ClassMetadataLayout.swift
@@ -20,23 +20,41 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+// Note: With the release of swift 5.4 the ClassMetadataLayout changed for platforms without Objective-C interoperability
+// see:  https://github.com/apple/swift/commit/38fc849a1fc8ea703de2fd1f280b43c682b70257#diff-22fb9f1513d9c05f34d493826b4553bba65a4336a41ae4413678feec549db3a5
+// related issue: https://github.com/wickwirew/Runtime/issues/92
+
 // Swift class or objc class
 struct AnyClassMetadataLayout {
     var _kind: Int // isaPointer for classes
     var superClass: Any.Type
+
+    // see comment above
+    #if !swift(>=5.4) || canImport(Darwin)
     var objCRuntimeReserve: (Int, Int)
     var rodataPointer: Int
+    #endif
     
     var isSwiftClass: Bool {
+        // see comment above
+        #if !swift(>=5.4) || canImport(Darwin)
         return (rodataPointer & classIsSwiftMask()) != 0
+        #else
+        return true
+        #endif
     }
 }
 
 struct ClassMetadataLayout: NominalMetadataLayoutType {
     var _kind: Int // isaPointer for classes
     var superClass: Any.Type
+
+    // see comment above
+    #if !swift(>=5.4) || canImport(Darwin)
     var objCRuntimeReserve: (Int, Int)
     var rodataPointer: Int
+    #endif
+
     var classFlags: Int32
     var instanceAddressPoint: UInt32
     var instanceSize: UInt32

--- a/Sources/Runtime/Layouts/ClassMetadataLayout.swift
+++ b/Sources/Runtime/Layouts/ClassMetadataLayout.swift
@@ -30,14 +30,14 @@ struct AnyClassMetadataLayout {
     var superClass: Any.Type
 
     // see comment above
-    #if !swift(>=5.4) || canImport(Darwin)
+    #if !swift(>=5.4) || canImport(ObjectiveC)
     var objCRuntimeReserve: (Int, Int)
     var rodataPointer: Int
     #endif
     
     var isSwiftClass: Bool {
         // see comment above
-        #if !swift(>=5.4) || canImport(Darwin)
+        #if !swift(>=5.4) || canImport(ObjectiveC)
         return (rodataPointer & classIsSwiftMask()) != 0
         #else
         return true
@@ -50,7 +50,7 @@ struct ClassMetadataLayout: NominalMetadataLayoutType {
     var superClass: Any.Type
 
     // see comment above
-    #if !swift(>=5.4) || canImport(Darwin)
+    #if !swift(>=5.4) || canImport(ObjectiveC)
     var objCRuntimeReserve: (Int, Int)
     var rodataPointer: Int
     #endif

--- a/Tests/RuntimeTests/MetadataTests.swift
+++ b/Tests/RuntimeTests/MetadataTests.swift
@@ -51,7 +51,7 @@ class MetadataTests: XCTestCase {
         let info = md.toTypeInfo()
 
         // see comment in ClassMetadataLayout.swift
-        #if !swift(>=5.4) || canImport(Darwin)
+        #if !swift(>=5.4) || canImport(ObjectiveC)
         XCTAssert(md.genericArgumentOffset == 15)
         #else
         XCTAssert(md.genericArgumentOffset == 15 - 3)

--- a/Tests/RuntimeTests/MetadataTests.swift
+++ b/Tests/RuntimeTests/MetadataTests.swift
@@ -49,7 +49,14 @@ class MetadataTests: XCTestCase {
     func testClass() {
         var md = ClassMetadata(type: MyClass<Int>.self)
         let info = md.toTypeInfo()
+
+        // see comment in ClassMetadataLayout.swift
+        #if !swift(>=5.4) || canImport(Darwin)
         XCTAssert(md.genericArgumentOffset == 15)
+        #else
+        XCTAssert(md.genericArgumentOffset == 15 - 3)
+        #endif
+
         XCTAssert(info.properties.first {$0.name == "baseProperty"} != nil)
         XCTAssert(info.inheritance[0] == BaseClass.self)
         XCTAssert(info.superClass == BaseClass.self)


### PR DESCRIPTION
As described in https://github.com/wickwirew/Runtime/issues/92, swift 5.4 change the `ClassMetadataLayout` for platforms that do not support Objective-C interoperability. This resulted in Runtime crashing when running on those platforms with the newest swift releases.

This PR fixes this issue by adjusting the `ClassMetadataLayout` on those platforms.
I'm using the `#if !swift(>=5.4) || canImport(Darwin)`. Not entirely sure if `canImport(Darwin)` is the proper check for availability of Objective-C interoperability (works though). Happy for any feedback.

I have another PR ready which adds some CI integration with GitHub to test the framework on all the available linux distortions. This PR passes all tests on all platforms: [Actions Run](https://github.com/Supereg/Runtime/runs/2955421795?check_suite_focus=true).
I chose to do the CI PR separately so this fix can get merged faster.