### PR TITLE
Fix Factory `createInstance` for class types on linux platforms

### DIFF
--- a/Sources/Runtime/Factory/Factory.swift
+++ b/Sources/Runtime/Factory/Factory.swift
@@ -61,10 +61,15 @@ func buildClass(type: Any.Type) throws -> Any {
     var md = ClassMetadata(type: type)
     let info = md.toTypeInfo()
     let metadata = unsafeBitCast(type, to: UnsafeRawPointer.self)
-    let instanceSize = Int32(md.pointer.pointee.classSize)
-    let alignment = Int32(md.alignment)
+    let instanceSize = Int32(md.pointer.pointee.instanceSize)
 
-    guard let value = swift_allocObject(metadata, instanceSize, alignment) else {
+    // https://github.com/wickwirew/Runtime/issues/49
+    // Docs specify that the alignment should be "always one less than a power of 2 that's at least alignof(void*)"
+    // https://github.com/apple/swift/blob/7123d2614b5f222d03b3762cb110d27a9dd98e24/include/swift/Runtime/HeapObject.h#L56-L57
+    // We could use md.alignment and deduct 1, or just use the instanceAlignmentMask from the ClassMetadata.
+    let alignmentMask = Int32(md.pointer.pointee.instanceAlignmentMask)
+
+    guard let value = swift_allocObject(metadata, instanceSize, alignmentMask) else {
             throw RuntimeError.unableToBuildType(type: type)
     }
 

--- a/Tests/RuntimeTests/GetSetStructTests.swift
+++ b/Tests/RuntimeTests/GetSetStructTests.swift
@@ -29,6 +29,7 @@ class GetSetStructTests: XCTestCase {
     static var allTests: [(String, (GetSetStructTests) -> () throws -> Void)] {
         return [
             ("testGet", testGet),
+            ("testGetSimple", testGetSimple),
             ("testGetUntypedValue", testGetUntypedValue),
             ("testGetUntypedObject", testGetUntypedObject),
             ("testGetUntyped", testGetUntyped),

--- a/Tests/RuntimeTests/MetadataTests.swift
+++ b/Tests/RuntimeTests/MetadataTests.swift
@@ -220,15 +220,15 @@ class MetadataTests: XCTestCase {
         XCTAssert(hasPayload.payloadType == Int.self)
         XCTAssert(hasTuplePayload.payloadType == (Bool, Int).self)
     }
-    
-    #if canImport(Foundation)
+
     func testObjcEnum() {
+        #if canImport(Foundation)
         var md = EnumMetadata(type: ComparisonResult.self)
         let info = md.toTypeInfo()
         XCTAssertEqual(info.numberOfEnumCases, 3)
         XCTAssertEqual(info.numberOfPayloadEnumCases, 0)
+        #endif
     }
-    #endif
     
     func testOptional() throws {
         let info = try typeInfo(of: Double?.self)

--- a/Tests/RuntimeTests/XCTestManifests.swift
+++ b/Tests/RuntimeTests/XCTestManifests.swift
@@ -3,7 +3,9 @@ import XCTest
 extension FactoryTests {
     static let __allTests = [
         ("testStruct", testStruct),
-        ("testStructUntyped", testStructUntyped)
+        ("testStructUntyped", testStructUntyped),
+        ("testClass", testClass),
+        ("testGenericClass", testGenericClass)
     ]
 }
 
@@ -40,6 +42,7 @@ extension GetSetClassTests {
 extension GetSetStructTests {
     static let __allTests = [
         ("testGet", testGet),
+        ("testGetSimple", testGetSimple),
         ("testGetArray", testGetArray),
         ("testGetArrayUntyped", testGetArrayUntyped),
         ("testGetArrayUntypedObject", testGetArrayUntypedObject),
@@ -71,14 +74,20 @@ extension GetSetStructTests {
 extension MetadataTests {
     static let __allTests = [
         ("testClass", testClass),
-        ("testEnum", testEnum),
-        ("testFunction", testFunction),
-        ("testFunctionThrows", testFunctionThrows),
-        ("testProtocol", testProtocol),
+        ("testResilientClass", testResilientClass),
         ("testStruct", testStruct),
+        ("testGenericStruct", testGenericStruct),
+        ("testNestedStruct", testNestedStruct),
+        ("testProtocol", testProtocol),
         ("testTuple", testTuple),
         ("testTupleNoLabels", testTupleNoLabels),
-        ("testVoidFunction", testVoidFunction)
+        ("testFunction", testFunction),
+        ("testFunctionThrows", testFunctionThrows),
+        ("testVoidFunction", testVoidFunction),
+        ("testEnum", testEnum),
+        ("testEnumTestEnumWithPayload", testEnumTestEnumWithPayload),
+        ("testObjcEnum", testObjcEnum),
+        ("testOptional", testOptional)
     ]
 }
 


### PR DESCRIPTION
My comment in https://github.com/wickwirew/Runtime/issues/49#issuecomment-872265231 explains the issue and how to resolve (to my understanding and knowledge) in detail.

The changes in this PR have proven to be working: see [GitHub CI Run](https://github.com/Supereg/Runtime/actions/runs/990268989) (Note this run includes the PRs #93 and #94)

This PR makes two adjustments to the `createClass` method:
* It fixes the discussed alignmentMask property passed to the Swift Runtime
* It replaces `let instanceSize = Int32(md.pointer.pointee.classSize)` with `let instanceSize = Int32(md.pointer.pointee.instanceSize)`
 To my knowledge and careful reading through the [Class Metadata Layout docs](https://github.com/apple/swift/blob/main/docs/ABI/TypeMetadata.rst#class-metadata) to me, using `.classSize` here seems wrong. The value is not constant across platforms while `instanceSize` is. I'm not really an expert with the Swift Runtime, so feel free to correct me if I'm wrong.

Further, this PR reenables some tests cases which were previously skipped on linux platforms (which allowed for this issue being unnoticed).
