### PR TITLE
Fixed podspec syntax for macos

### DIFF
--- a/Runtime.podspec
+++ b/Runtime.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
     s.author       = { "Wesley Wickwire" => "wickwirew@gmail.com" }
     s.ios.deployment_target = '9.0'
     s.tvos.deployment_target = '9.0'
-    s.macos.deployment_target = '10.10'
+    s.osx.deployment_target = '10.10'
     s.source       = { :git => "https://github.com/wickwirew/Runtime.git", :tag => s.version }
     s.source_files = 'Sources/**/*.{swift,h}'
 end


### PR DESCRIPTION
Fixed the wrong format which was leading to an error when trying to setup a osx project
`s.macos.deployment_target = '10.10'` -> `s.osx.deployment_target = '10.10'`
