### PR TITLE
Fix bit mask of numberArguments

### DIFF
--- a/Sources/Runtime/Metadata/FuntionMetadata.swift
+++ b/Sources/Runtime/Metadata/FuntionMetadata.swift
@@ -43,7 +43,7 @@ struct FunctionMetadata: MetadataType {
     }
     
     private func numberArguments() -> Int {
-        return pointer.pointee.flags & 0x00FFFFFF
+        return pointer.pointee.flags & 0x0000FFFF
     }
     
     private func `throws`() -> Bool {


### PR DESCRIPTION
Hi, I think it is a great library.

I have found that the wrong number of parameters is returned when retrieving FunctionInfo for the following closure.

```swift
let t = (@convention(thin) (Int, String) async throws -> String).self

let md = FunctionMetadata(type: t)
let info = md.info()
print(info.numberOfArguments) // -> 131074
```

It seems to be caused by an incorrect bit mask.

https://github.com/apple/swift/blob/ade2671aee6853e3b76511a9c9a57945676ef237/include/swift/ABI/MetadataValues.h#L1029-L1042

Here is my Swift environment
```
(Apple Swift version 5.9 (swiftlang-5.9.0.128.108 clang-1500.0.40.1))
```